### PR TITLE
Adds functionality to select a single level

### DIFF
--- a/mpas_xarray/mpas_xarray.py
+++ b/mpas_xarray/mpas_xarray.py
@@ -120,7 +120,7 @@ def preprocess_mpas(ds, yearoffset=1850, onlyvars=None): #{{{
 
 def preprocess_mpas_timeSeriesStats(ds,
         timestr='timeSeriesStatsMonthly_avg_daysSinceStartOfSim_1',
-        yearoffset=1849, monthoffset=12, dayoffset=31, onlyvars=None): #{{{
+        yearoffset=1849, monthoffset=12, dayoffset=31, onlyvars=None, vertLevel=None): #{{{
     """
     Builds corret time specification for MPAS timeSeriesStats analysis member fields,
     allowing a date offset because the time must be between 1678 and 2262
@@ -145,6 +145,9 @@ def preprocess_mpas_timeSeriesStats(ds,
     daysSinceStart = ds[timestr]
     datetimes = [datetime.datetime(yearoffset, monthoffset, dayoffset) + datetime.timedelta(x)
                  for x in daysSinceStart.values]
+
+    if vertLevel is not None:
+        ds = ds.sel(nVertLevels = vertLevel)
 
     ds = general_processing(ds, datetimes, yearoffset, onlyvars)
 


### PR DESCRIPTION
This adds the ability to choose a single level for preprocessing.  This
was necessary for generating horizontal cross section comparisons from
3-D volumes.  Testing in the sst_climatology script showed a fairly
significant improvement in processing time with this change.
