### PR TITLE
Ensures input to subset_variables is a list

### DIFF
--- a/mpas_xarray/mpas_xarray.py
+++ b/mpas_xarray/mpas_xarray.py
@@ -68,6 +68,20 @@ def assert_valid_datetimes(datetimes, yearoffset): #{{{
 
     return #}}}
 
+def ensure_list(alist): #{{{
+    """
+    Ensure that variables used as a list are actually lists.
+
+    Phillip J. Wolfram
+    09/08/2016
+    """
+
+    if isinstance(alist, str):
+        #print 'Warning, converting %s to a list'%(alist)
+        alist = [alist]
+
+    return alist #}}}
+
 def general_processing(ds, datetimes, yearoffset, onlyvars): #{{{
     """
     Simple commonly used preprocessing commands general to multiple
@@ -85,7 +99,7 @@ def general_processing(ds, datetimes, yearoffset, onlyvars): #{{{
     ds.attrs.__setitem__('time_yearoffset', str(yearoffset))
 
     if onlyvars is not None:
-        ds = subset_variables(ds, onlyvars)
+        ds = subset_variables(ds, ensure_list(onlyvars))
 
     return ds #}}}
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 from setuptools import setup
 
 setup(name='mpas_xarray',
-        version='0.0.1',
+        version='0.0.2',
         description='Wrapper for xarray to interface with MPAS *.nc files',
         url='https://github.com/pwolfram/mpas_xarray/',
         maintainer='Phillip J. Wolfram',


### PR DESCRIPTION
Prevents errors when onlyvars is a string.
