### PR TITLE
Generalized preprocessing slicing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,10 @@ The module does the following:
 2. Converts MPAS "timeSinceStartOfSim"
    to xarray time for MPAS fields coming from the timeSeriesStatsAM. Time
    dimension is assigned via ``preprocess_mpas(...,timeSeriesStats=True)``.
-3. Provides capability to remove redundant time entries from reading of
+3. Allows generalized selection of variables via ``preprocess_mpas(..., onlyvars=['var1','var2'])``
+   and slicing via ``preprocess_mpas(..., iselvals={'nVertLevels':1})`` and
+   ``preprocess_mpas(..., selvals={'lonCell':180.0})``.
+4. Provides capability to remove redundant time entries from reading of
    multiple netCDF datasets via ``remove_repeated_time_index``.
 
 Example Usage:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 from setuptools import setup
 
 setup(name='mpas_xarray',
-        version='0.0.3',
+        version='0.0.4',
         description='Wrapper for xarray to interface with MPAS *.nc files',
         url='https://github.com/pwolfram/mpas_xarray/',
         maintainer='Phillip J. Wolfram',


### PR DESCRIPTION
Input dictionaries are used to define slicing methods
to be applied prior to xarray concatenation, e.g.,
selvals and iselvals.

This addresses https://github.com/pwolfram/mpas_xarray/issues/12

cc @vanroekel, @milenaveneziani 
